### PR TITLE
Update example author to be less misleading

### DIFF
--- a/manifest/com.example/author.json
+++ b/manifest/com.example/author.json
@@ -1,6 +1,6 @@
 {
 	"author": {
-		"AuthorName": {
+		"ExampleAuthor": {
 			"url": "https://github.com/resonite-modding-group"
 		}
 	}


### PR DESCRIPTION
I didn't realize that "AuthorName" was something I'm supposed to change, because it sounds like a plausible json key. I think "ExampleAuthor" sounds much more like something you need to replace