### PR TITLE
Add NoTankControls v1.0.0-resonite

### DIFF
--- a/manifest/U-xyla/NoTankControls/info.json
+++ b/manifest/U-xyla/NoTankControls/info.json
@@ -1,0 +1,16 @@
+{
+	"name": "NoTankControls",
+	"id": "U-xyla.XyMod",
+	"description": "Don't lock up joystick movement while tools are equipped. Very helpful on Quest.",
+	"category": "Controls",
+	"sourceLocation": "https://github.com/furrz/NoTankControls",
+	"versions": {
+		"1.0.0": {
+			"releaseUrl": "https://github.com/furrz/NoTankControls/releases/tag/1.0.0-resonite",
+			"artifacts": [{
+				"url": "https://github.com/furrz/NoTankControls/releases/download/1.0.0-resonite/NoTankControls.dll",
+				"sha256": "f80b301222a8cf7c1529d114f28380f826005929d7f77a309125fd01f4f05117"
+			}]
+		}
+	}
+}

--- a/manifest/U-xyla/author.json
+++ b/manifest/U-xyla/author.json
@@ -1,0 +1,7 @@
+{
+	"author": {
+		"Zyntaks": {
+			"url": "https://github.com/furrz"
+		}
+	}
+}


### PR DESCRIPTION
Note that the prefix used is U-xyla, my old Neos username, as I didn't change the harmony Mod ID when releasing the Resonite version. I would give it an appropriate 'reverse domain' style prefix, but I don't want to update the mod unnecessarily.