### PR TITLE
made by calamity lime List of Changes:

### DIFF
--- a/manifest/u-alexderpyfox/ExampleMod/info.json
+++ b/manifest/u-alexderpyfox/ExampleMod/info.json
@@ -1,0 +1,16 @@
+{
+	"name": "LocalStorageV2 (Lime fork)",
+	"id": "me.CalamityLime.LocalStorage",
+	"description": "local storage with ability to save Files with same name Without it overwriting. And now saves Files with special characters",
+	"category": "Technical Tweaks",
+	"sourceLocation": "https://github.com/LimeProgramming/LocalStorage",
+	"versions": {
+		"1.0.0": {
+			"releaseUrl": "https://github.com/LimeProgramming/LocalStorage/tag/2.0.3",
+			"artifacts": [{
+				"url": "https://github.com/LimeProgramming/LocalStorage/releases/download/2.0.3/LocalStorage.dll",
+				"sha256": "b4ca41ac353429c8e57e14a467a92f69c7dbc4399c7463583b7c37278e35ec34"
+			}]
+		}
+	}
+}

--- a/manifest/u-alexderpyfox/author.json
+++ b/manifest/u-alexderpyfox/author.json
@@ -1,0 +1,7 @@
+{
+	"author": {
+		"alexderpyfox": {
+			"url": "https://github.com/alexderpyfox"
+		}
+	}
+}


### PR DESCRIPTION
You can save items with the same name into the same folder. Item thumbnails are saved to a dedicated folder since I like to clear the cache that Resonite dumps in the AppData\LocalLow folder. Folder names have invalid characters removed from them automatically, this is reflected in Resonite. Resonite allowed file/folder names with characters that Windows does not allow in paths. The Local Storage button is now brick red, I just like it but maybe I'll change it just to keep you on your toes, who knows.

<!-- This template is provided for your convenience: feel free to delete it from your PR -->

- [ ] The mod id matches the harmony id if used by the mod and starts with the same id as your author folder
- [ ] All used links are valid
- [ ] Your ResoniteMod.Version must match the version being added in the manifest
- [ ] Your AssemblyVersion should match the mod version
- [x] You have included an accurate `sha256` hash for each artifact
- [ ] Do not remove old mods. Instead, use the `deprecated` flag
- [x] Follow the [Resonite Policies and Guidelines](https://resonite.com/policies/) and [Mod Submission Guidelines](https://github.com/resonite-modding-group/resonite-mod-manifest/wiki/Submission-Guidelines)
