### PR TITLE
add im gui stuff

### DIFF
--- a/manifest/me.art0007i/ImGuiUnityInject/info.json
+++ b/manifest/me.art0007i/ImGuiUnityInject/info.json
@@ -1,0 +1,29 @@
+{
+    "name": "ImGuiUnityInject",
+    "id": "me.art0007i.ImGuiUnityInject",
+    "description": "Edit of https://github.com/realgamessoftware/dear-imgui-unity to work with game modding",
+    "category": "Libraries",
+    "sourceLocation": "https://github.com/art0007i/ImGuiUnityInject",
+    "versions": {
+        "0.1.1": {
+            "releaseUrl": "https://github.com/art0007i/ImGuiUnityInject/releases/tag/0.1.1",
+            "artifacts": [
+                {
+                    "url": "https://github.com/art0007i/ImGuiUnityInject/releases/download/0.1.1/ImGuiUnityInject.dll",
+                    "filename": "../rml_libs/ImGuiUnityInject.dll",
+                    "sha256": "3c8735b22d05e6136c10a3132800084a4e42ed803b059bc2820c0ab8d4b4bfd9"
+                },
+                {
+                    "url": "https://github.com/art0007i/ImGuiUnityInject/raw/d5c5ab8208bf4b6bd5f6dec0756573b85c1d0e61/Plugins/cimgui-freetype.dll",
+                    "filename": "../Resonite_Data/Plugins/x86_64/cimgui-freetype.dll",
+                    "sha256": "e43759ef30a1c02fb0dec1dc232873fb576f6c6483de0c7a5e7e7157fad5cf10"
+                },
+                {
+                    "url": "https://github.com/art0007i/ImGuiUnityInject/raw/d5c5ab8208bf4b6bd5f6dec0756573b85c1d0e61/Plugins/cimgui.dll",
+                    "filename": "../Resonite_Data/Plugins/x86_64/cimgui.dll",
+                    "sha256": "09bb9d5e23137e3b2ee681a1700a3a0f4bd847846368ede847a163f1f91e8560"
+                }
+            ]
+        }
+    }
+}

--- a/manifest/me.art0007i/ImGuiUnityInject/info.json
+++ b/manifest/me.art0007i/ImGuiUnityInject/info.json
@@ -10,17 +10,20 @@
             "artifacts": [
                 {
                     "url": "https://github.com/art0007i/ImGuiUnityInject/releases/download/0.1.1/ImGuiUnityInject.dll",
-                    "filename": "../rml_libs/ImGuiUnityInject.dll",
+                    "filename": "ImGuiUnityInject.dll",
+                    "installLocation": "/rml_libs",
                     "sha256": "3c8735b22d05e6136c10a3132800084a4e42ed803b059bc2820c0ab8d4b4bfd9"
                 },
                 {
                     "url": "https://github.com/art0007i/ImGuiUnityInject/raw/d5c5ab8208bf4b6bd5f6dec0756573b85c1d0e61/Plugins/cimgui-freetype.dll",
-                    "filename": "../Resonite_Data/Plugins/x86_64/cimgui-freetype.dll",
+                    "filename": "cimgui-freetype.dll",
+                    "installLocation": "/Resonite_Data/Plugins/x86_64",
                     "sha256": "e43759ef30a1c02fb0dec1dc232873fb576f6c6483de0c7a5e7e7157fad5cf10"
                 },
                 {
                     "url": "https://github.com/art0007i/ImGuiUnityInject/raw/d5c5ab8208bf4b6bd5f6dec0756573b85c1d0e61/Plugins/cimgui.dll",
-                    "filename": "../Resonite_Data/Plugins/x86_64/cimgui.dll",
+                    "filename": "cimgui.dll",
+                    "installLocation": "/Resonite_Data/Plugins/x86_64",
                     "sha256": "09bb9d5e23137e3b2ee681a1700a3a0f4bd847846368ede847a163f1f91e8560"
                 }
             ]

--- a/manifest/me.art0007i/ResoniteImGuiLib/info.json
+++ b/manifest/me.art0007i/ResoniteImGuiLib/info.json
@@ -1,0 +1,24 @@
+{
+    "name": "ResoniteImGuiLib",
+    "id": "me.art0007i.ResoniteImGuiLib",
+    "description": "A library which allows modders to use ImGuiUnityInject in resonite",
+    "category": "Libraries",
+    "sourceLocation": "https://github.com/art0007i/ResoniteImGuiLib",
+    "versions": {
+        "1.0.0": {
+            "releaseUrl": "https://github.com/art0007i/ResoniteImGuiLib/releases/tag/1.0.0",
+            "artifacts": [
+                {
+                    "url": "https://github.com/art0007i/ResoniteImGuiLib/releases/download/1.0.0/ResoniteImGuiLib.dll",
+                    "filename": "ResoniteImGuiLib.dll",
+                    "sha256": "531ad310a61df024569a6eb3c58b2e222f4dca0f8ad53e3003ad6a483aef1afd"
+                }
+            ],
+            "dependencies": {
+                "me.art0007i.ImGuiUnityInject": {
+                    "version": "0.1.x"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
so ImGuiUnityInject is probably a pretty weird one to add

The cimgui dlls are sourced from me making a fresh unity project on unity 2019, copying the entire plugins folder from https://github.com/realgamessoftware/dear-imgui-unity/tree/master/Plugins into assets, and building the game. After this I simply took the dlls from the build and those are the ones present here.

also idk if the artifact filenames are supposed to be like they are