### PR TITLE
Deprecate Outflow

### DIFF
--- a/manifest/net.Cyro/Outflow/info.json
+++ b/manifest/net.Cyro/Outflow/info.json
@@ -4,6 +4,7 @@
 	"description": "Mitigate hitching when new users join a session you are hosting",
 	"category": "Optimization",
 	"sourceLocation": "https://github.com/BlueCyro/Outflow/",
+	"flags": ["deprecated"],
 	"versions": {
 		"1.0.1": {
 			"releaseUrl": "https://github.com/BlueCyro/Outflow/releases/tag/1.0.1",


### PR DESCRIPTION
No longer should be needed as of 2024.9.30.1215
