### PR TITLE
Added 3DDashOnScreenResonite to manifest

### DIFF
--- a/manifest/net.rampa3/Resonite3DDashOnScreen/info.json
+++ b/manifest/net.rampa3/Resonite3DDashOnScreen/info.json
@@ -1,0 +1,16 @@
+{
+	"name": "3DDashOnScreenResonite",
+	"id": "net.rampa3.3DDashOnScreenResonite",
+	"description": "Resonite Mod Loader mod, that replaces 2D overlay dash in Screen mode with the regular VR one",
+	"category": "Dashboard",
+	"sourceLocation": "https://github.com/rampa3/3DDashOnScreenResonite",
+	"versions": {
+		"3.6.0": {
+			"releaseUrl": "https://github.com/rampa3/3DDashOnScreenResonite/releases/tag/3.6.0.0",
+			"artifacts": [{
+				"url": "https://github.com/rampa3/3DDashOnScreenResonite/releases/download/3.6.0.0/3DDashOnScreenResonite.dll",
+				"sha256": "d823220ae977fa28fe30db39e030eb0642e9d2f2aa80f2a834147303148d5f8a"
+			}]
+		}
+	}
+}

--- a/manifest/net.rampa3/Resonite3DDashOnScreen/info.json
+++ b/manifest/net.rampa3/Resonite3DDashOnScreen/info.json
@@ -11,6 +11,13 @@
 				"url": "https://github.com/rampa3/3DDashOnScreenResonite/releases/download/3.6.0.0/3DDashOnScreenResonite.dll",
 				"sha256": "fe56959ff282e994aeff8b67fd0700916ba539a8f175faf377a999e899fc3284"
 			}]
+		},
+		"3.6.1": {
+			"releaseUrl": "https://github.com/rampa3/3DDashOnScreenResonite/releases/tag/3.6.1.0",
+			"artifacts": [{
+				"url": "https://github.com/rampa3/3DDashOnScreenResonite/releases/download/3.6.1.0/3DDashOnScreenResonite.dll",
+				"sha256": "28346faa13547a8ce4c63d7d52011d5d32814173393c44e11829d237765f114f"
+			}]
 		}
 	}
 }

--- a/manifest/net.rampa3/Resonite3DDashOnScreen/info.json
+++ b/manifest/net.rampa3/Resonite3DDashOnScreen/info.json
@@ -9,7 +9,7 @@
 			"releaseUrl": "https://github.com/rampa3/3DDashOnScreenResonite/releases/tag/3.6.0.0",
 			"artifacts": [{
 				"url": "https://github.com/rampa3/3DDashOnScreenResonite/releases/download/3.6.0.0/3DDashOnScreenResonite.dll",
-				"sha256": "d823220ae977fa28fe30db39e030eb0642e9d2f2aa80f2a834147303148d5f8a"
+				"sha256": "fe56959ff282e994aeff8b67fd0700916ba539a8f175faf377a999e899fc3284"
 			}]
 		}
 	}

--- a/manifest/net.rampa3/author.json
+++ b/manifest/net.rampa3/author.json
@@ -1,0 +1,7 @@
+{
+	"author": {
+		"rampa3": {
+			"url": "https://github.com/rampa3"
+		}
+	}
+}


### PR DESCRIPTION
This PR adds all currently avalable versions of 3DDashOnScreenResonite to the manifest. It is combination of never made PR for the initial version of 3DDashOnScreenResonite, and PR for current update, which merges commit https://github.com/rampa3/3DDashOnScreenResonite/commit/a3a95a5799922ba00cc45dc990e31f3b7f35dae4 from [NepuShiro](https://github.com/NepuShiro), fixing the mod after breakage on the latest version of Resonite.