### PR TITLE
Update HeadlessPrometheusExporter 1.2.2

### DIFF
--- a/manifest/lc.j4/HeadlessPrometheusExporter/info.json
+++ b/manifest/lc.j4/HeadlessPrometheusExporter/info.json
@@ -8,6 +8,14 @@
   ],
   "sourceLocation": "https://g.j4.lc/general-stuff/resonite/headless-prometheus-exporter",
   "versions": {
+    "1.2.2": {
+      "releaseUrl": "https://g.j4.lc/general-stuff/resonite/headless-prometheus-exporter/-/releases/1.2.2",
+      "artifacts": [{
+        "url": "https://g.j4.lc/general-stuff/resonite/headless-prometheus-exporter/-/releases/1.2.2/downloads/HeadlessPrometheusExporter.dll",
+        "filename": "HeadlessPrometheusExporter.dll",
+        "sha256": "bb12615a2e2d7e4d6084d3597d8faf3f3baa40191fc78f98e745f28bcb8c9c58"
+      }]
+    },
     "1.2.1": {
       "releaseUrl": "https://g.j4.lc/general-stuff/resonite/headless-prometheus-exporter/-/releases/1.2.1",
       "artifacts": [{


### PR DESCRIPTION
<!-- This template is provided for your convenience: feel free to delete it from your PR -->

- [x] The mod id matches the harmony id if used by the mod and starts with the same id as your author folder
- [x] All used links are valid
- [x] Your ResoniteMod.Version must match the version being added in the manifest and follow [Semantic Versioning](https://semver.org/)
- [x] Your AssemblyVersion should match the mod version
- [x] You have included an accurate `sha256` hash for each artifact
- [x] Do not remove old mods. Instead, use the `deprecated` flag
- [x] Follow the [Resonite Policies and Guidelines](https://resonite.com/policies/) and [Mod Submission Guidelines](https://github.com/resonite-modding-group/resonite-mod-manifest/wiki/Submission-Guidelines)

Update 1.2.2 building against .NET 9 + security fix in System.Text.Json.

https://g.j4.lc/general-stuff/resonite/headless-prometheus-exporter/-/releases/1.2.2