### PR TITLE
Mark Thundagun as deprecated

### DIFF
--- a/manifest/com.frozenreflex/Thundagun/info.json
+++ b/manifest/com.frozenreflex/Thundagun/info.json
@@ -4,6 +4,9 @@
 	"description": "A lightning fast performance mod for Resonite. It improves performance by decoupling the FrooxEngine and Unity loops by running FrooxEngine and Unity on separate threads.",
 	"category": "Optimization",
 	"sourceLocation": "https://github.com/Frozenreflex/Thundagun",
+	"flags": [
+		"deprecated"
+	],
 	"additionalAuthors": [
 		"989onan",
 		"DoubleStyx",


### PR DESCRIPTION
The version of the mod that is on the manifest is crashing. It is also missing a lot of stuff for PhotonDust and SphericalHarmonics which lead to particles not showing and world ambient lighting not working.

I may add this missing stuff later, but for now I think the mod should be hidden so people don't download it and then have a bad experience.