### PR TITLE
Update ResoniteMP3 to V2.1.0

### DIFF
--- a/manifest/com.__Choco__/ResoniteMP3/info.json
+++ b/manifest/com.__Choco__/ResoniteMP3/info.json
@@ -5,6 +5,30 @@
 	"category": "Asset Importing",
 	"sourceLocation": "https://github.com/AwesomeTornado/ResoniteMP3",
 	"versions": {
+		"2.1.0": {
+			"releaseUrl": "https://github.com/AwesomeTornado/ResoniteMP3/releases/tag/V2.1.0",
+			"artifacts": [
+				{
+					"url": "https://github.com/AwesomeTornado/ResoniteMP3/releases/download/V2.1.0/ResoniteMP3.dll",
+					"sha256": "a962f9d9000ef8cba467e6059f0a327c0dae78c3364b5b415f3b7e0ec9f14625"
+				},
+				{
+					"url": "https://github.com/AwesomeTornado/ResoniteMP3/releases/download/V2.1.0/NAudio.Core.dll",
+					"installLocation": "/rml_libs",
+					"sha256": "fcf493fc47a2f478a65303886b975fbdbf714cbb1f2d79f7fce97e4bb16b01a8"
+				},
+				{
+					"url": "https://github.com/AwesomeTornado/ResoniteMP3/releases/download/V2.1.0/NAudio.dll",
+					"installLocation": "/rml_libs",
+					"sha256": "8bf0f2e8dadf3967757191c2212c269333ccd9d7e59839eea968212c64787be9"
+				},
+				{
+					"url": "https://github.com/AwesomeTornado/ResoniteMP3/releases/download/V2.1.0/NAudio.WinMM.dll",
+					"installLocation": "/rml_libs",
+					"sha256": "749a01ebbb5edd8b1a03c5263b04de6acadecf52e4cc84d7412bc6e93f180958"
+				}
+			]
+		},
 		"2.0.0": {
 			"releaseUrl": "https://github.com/AwesomeTornado/ResoniteMP3/releases/tag/V2.0.0",
 			"artifacts": [


### PR DESCRIPTION
Add version 2.1.0 of ResoniteMP3
QOL improvements: Removed random filenames.

This mod update only changes how temp files are stored. Instead of randomizing filenames in order to prevent conflicts, a new randomly named folder is created on every import which contains the properly named file within. All of these folders are still contained inside of the temp folder made for ResoniteMP3, and deleted on app start.

- [x] The mod id matches the harmony id if used by the mod and starts with the same id as your author folder
- [x] All used links are valid
- [x] Your ResoniteMod.Version must match the version being added in the manifest and follow [Semantic Versioning](https://semver.org/)
- [x] Your AssemblyVersion should match the mod version
- [x] You have included an accurate `sha256` hash for each artifact
- [x] Do not remove old mods. Instead, use the `deprecated` flag
- [x] Follow the [Resonite Policies and Guidelines](https://resonite.com/policies/) and [Mod Submission Guidelines](https://github.com/resonite-modding-group/resonite-mod-manifest/wiki/Submission-Guidelines)
