### PR TITLE
HeadlessTweaks v2.1.9

### DIFF
--- a/manifest/dev.discordnet/Core/info.json
+++ b/manifest/dev.discordnet/Core/info.json
@@ -1,0 +1,19 @@
+{
+	"name": "Discord.Net.Core",
+	"id": "dev.discordnet.Core",
+	"description": "The core components for the Discord.Net library.",
+	"category": "Libraries",
+	"sourceLocation": "https://github.com/discord-net/Discord.Net",
+	"website": "https://discordnet.dev/",
+	"versions": {
+		"3.17.0": {
+			"releaseUrl": "https://github.com/discord-net/Discord.Net/releases/tag/3.17.0",
+			"artifacts": [{
+				"url": "https://github.com/New-Project-Final-Final-WIP/HeadlessTweaks/releases/download/v2.1.9/Discord.Net.Core.dll",
+				"filename": "Discord.Net.Core.dll",
+				"sha256": "a82431fc7ac64743e1846d6d553ffa324a93fe69dcd6c1815c3cb3ec4ab9e235",
+				"installLocation": "/rml_libs"
+			}]
+		}
+	}
+}

--- a/manifest/dev.discordnet/Rest/info.json
+++ b/manifest/dev.discordnet/Rest/info.json
@@ -1,0 +1,24 @@
+{
+	"name": "Discord.Net.Rest",
+	"id": "dev.discordnet.Rest",
+	"description": "The rest components for the Discord.Net library.",
+	"category": "Libraries",
+	"sourceLocation": "https://github.com/discord-net/Discord.Net",
+	"website": "https://discordnet.dev/",
+	"versions": {
+		"3.17.0": {
+			"releaseUrl": "https://github.com/discord-net/Discord.Net/releases/tag/3.17.0",
+			"artifacts": [{
+				"url": "https://github.com/New-Project-Final-Final-WIP/HeadlessTweaks/releases/download/v2.1.9/Discord.Net.Rest.dll",
+				"filename": "Discord.Net.Rest.dll",
+				"sha256": "9f0675905bfef39076654bd904956604e18fedcfff67075e34e50cef0bab5427",
+				"installLocation": "/rml_libs"
+			}],
+			"dependencies": {
+				"dev.discordnet.Core": {
+					"version": "^3.17.0"
+				}
+			}
+		}
+	}
+}

--- a/manifest/dev.discordnet/Webhook/info.json
+++ b/manifest/dev.discordnet/Webhook/info.json
@@ -1,0 +1,27 @@
+{
+	"name": "Discord.Net.Webhook",
+	"id": "dev.discordnet.Webhook",
+	"description": "The webhook components for the Discord.Net library.",
+	"category": "Libraries",
+	"sourceLocation": "https://github.com/discord-net/Discord.Net",
+	"website": "https://discordnet.dev/",
+	"versions": {
+		"3.17.0": {
+			"releaseUrl": "https://github.com/discord-net/Discord.Net/releases/tag/3.17.0",
+			"artifacts": [{
+				"url": "https://github.com/New-Project-Final-Final-WIP/HeadlessTweaks/releases/download/v2.1.9/Discord.Net.Webhook.dll",
+				"filename": "Discord.Net.Webhook.dll",
+				"sha256": "cda28bd16c518ed8c44618d0c7a8548c10f462ffc0e66aed1551d945e339df58",
+				"installLocation": "/rml_libs"
+			}],
+			"dependencies": {
+				"dev.discordnet.Core": {
+					"version": "^3.17.0"
+				},
+				"dev.discordnet.Rest": {
+					"version": "^3.17.0"
+				}
+			}
+		}
+	}
+}

--- a/manifest/dev.discordnet/author.json
+++ b/manifest/dev.discordnet/author.json
@@ -2,7 +2,7 @@
 	"author": {
 		"pardeike": {
 			"url": "https://github.com/discord-net",
-			"icon": "https://raw.githubusercontent.com/discord-net/Discord.Net/dev/docs/marketing/logo/PackageLogo.png",
+			"icon": "https://github.com/discord-net.png",
 			"website": "https://discordnet.dev/",
 			"support": "https://opencollective.com/discordnet"
 		}

--- a/manifest/dev.discordnet/author.json
+++ b/manifest/dev.discordnet/author.json
@@ -1,0 +1,10 @@
+{
+	"author": {
+		"pardeike": {
+			"url": "https://github.com/discord-net",
+			"icon": "https://raw.githubusercontent.com/discord-net/Discord.Net/dev/docs/marketing/logo/PackageLogo.png",
+			"website": "https://discordnet.dev/",
+			"support": "https://opencollective.com/discordnet"
+		}
+	}
+}

--- a/manifest/page.newweb/HeadlessTweaks/info.json
+++ b/manifest/page.newweb/HeadlessTweaks/info.json
@@ -1,7 +1,7 @@
 {
 	"name": "HeadlessTweaks",
 	"id": "page.newweb.HeadlessTweaks",
-	"description": "Adds some nice to have features to headless clients. To use the discord related options `Discord.Net.Webhook`, `Discord.Net.Rest`, and `Discord.Net.Core` libraries are required, view the readme for more information.",
+	"description": "Adds some nice to have features to headless clients. The net9 version of harmonylib is required. To use the discord related options `Discord.Net.Webhook`, `Discord.Net.Rest`, and `Discord.Net.Core` libraries are required, view the readme for more information.",
 	"category": "Technical Tweaks",
 	"platforms": [
 		"headless"

--- a/manifest/page.newweb/HeadlessTweaks/info.json
+++ b/manifest/page.newweb/HeadlessTweaks/info.json
@@ -1,0 +1,21 @@
+{
+	"name": "HeadlessTweaks",
+	"id": "page.newweb.HeadlessTweaks",
+	"description": "Adds some nice to have features to headless clients. To use the discord related options `Discord.Net.Webhook`, `Discord.Net.Rest`, and `Discord.Net.Core` libraries are required, view the readme for more information.",
+	"category": "Technical Tweaks",
+	"platforms": [
+		"headless"
+	],
+	"website": "https://github.com/New-Project-Final-Final-WIP/HeadlessTweaks/blob/master/README.md",
+	"sourceLocation": "https://github.com/New-Project-Final-Final-WIP/HeadlessTweaks",
+	"versions": {
+		"2.1.9": {
+			"releaseUrl": "https://github.com/New-Project-Final-Final-WIP/HeadlessTweaks/releases/tag/v2.1.9",
+			"changelog": "- Added the option to automatically accept invite requests sent using the Ask to Join button (`AutoHandleInviteRequests`)\n  - This will send an invite for whatever session the headless is currently focused on\n  - This is only done if it is sent directly to the headless by the person requesting, this does not apply to forwarded requests\n  - The permission check is handled the same as the `/reqInvite` command\n  - If the user does not have permission to join then the request will be forwarded to the session admins\n\n- Discord changes\n  - Added `WorldCrashed` event\n  - Added option to add go.resonite.com link to session start message (`DiscordLinkToSession`)\n  \n- Command changes\n  - Added ability for `reqInvite` to do partial match\n  - Stop `reqInvite` command from reporting full world name if you do not have permission to join\n  - Fixed starting worlds with a world orb\n  - Fixed start world commands not always reporting a name\n\n- Misc changes\n  - Exposed RegisterCommands as a public method\n  - Updated project files\n",
+			"artifacts": [{
+				"url": "https://github.com/New-Project-Final-Final-WIP/HeadlessTweaks/releases/download/v2.1.9/HeadlessTweaks.dll",
+				"sha256": "edc53c2656d610396c6ee06b0e6d8365e8cbd5d47a7c95c27de575eeb3bc069a"
+			}]
+		}
+	}
+}

--- a/manifest/page.newweb/HeadlessTweaks/info.json
+++ b/manifest/page.newweb/HeadlessTweaks/info.json
@@ -1,7 +1,7 @@
 {
 	"name": "HeadlessTweaks",
 	"id": "page.newweb.HeadlessTweaks",
-	"description": "Adds some nice to have features to headless clients. The net9 version of harmonylib is required. To use the discord related options `Discord.Net.Webhook`, `Discord.Net.Rest`, and `Discord.Net.Core` libraries are required, view the readme for more information.",
+	"description": "Adds some nice to have features to headless clients. To use the discord related options `Discord.Net.Webhook`, `Discord.Net.Rest`, and `Discord.Net.Core` libraries are required, view the readme for more information.",
 	"category": "Technical Tweaks",
 	"platforms": [
 		"headless"

--- a/manifest/page.newweb/author.json
+++ b/manifest/page.newweb/author.json
@@ -1,0 +1,9 @@
+{
+	"author": {
+		"New_Project_Final_Final_WIP": {
+			"url": "https://github.com/New-Project-Final-Final-WIP",
+			"icon": "https://www.newweb.page/assets/images/logo.png",
+			"website": "https://newweb.page/"
+		}
+	}
+}


### PR DESCRIPTION
This includes 
- New_Project_Final_Final_WIP's author info 
- DiscordNet's Core, Rest, Webhook, and author info

This requires net9 and there's not a way to specify that currently
Also DiscordNet only shares downloads to NugetPackages, these dlls on the HeadlessTweaks release page are pulled from those

<!-- This template is provided for your convenience: feel free to delete it from your PR -->

- [X] The mod id matches the harmony id if used by the mod and starts with the same id as your author folder
- [X] All used links are valid
- [X] Your ResoniteMod.Version must match the version being added in the manifest and follow [Semantic Versioning](https://semver.org/)
- [X] Your AssemblyVersion should match the mod version
- [X] You have included an accurate `sha256` hash for each artifact
- [X] Do not remove old mods. Instead, use the `deprecated` flag
- [X] Follow the [Resonite Policies and Guidelines](https://resonite.com/policies/) and [Mod Submission Guidelines](https://github.com/resonite-modding-group/resonite-mod-manifest/wiki/Submission-Guidelines)
