### PR TITLE
Add mod: ResoniteAprilFools

### DIFF
--- a/manifest/com.__Choco__/ResoniteAprilFools/info.json
+++ b/manifest/com.__Choco__/ResoniteAprilFools/info.json
@@ -2,7 +2,7 @@
 	"name": "ResoniteAprilFools",
 	"id": "com.__Choco__.ResoniteAprilFools",
 	"description": "Activates all April Fools content even when it isn't April 1st.",
-	"category": "memes",
+	"category": "Memes",
 	"sourceLocation": "https://github.com/AwesomeTornado/ResoniteAprilFools",
 	"versions": {
 		"1.0.0": {

--- a/manifest/com.__Choco__/ResoniteAprilFools/info.json
+++ b/manifest/com.__Choco__/ResoniteAprilFools/info.json
@@ -1,0 +1,19 @@
+{
+	"name": "ResoniteAprilFools",
+	"id": "com.__Choco__.ResoniteAprilFools",
+	"description": "Activates all April Fools content even when it isn't April 1st.",
+	"category": "memes",
+	"sourceLocation": "https://github.com/AwesomeTornado/ResoniteAprilFools",
+	"versions": {
+		"1.0.0": {
+			"releaseUrl": "https://github.com/AwesomeTornado/ResoniteAprilFools/releases/tag/v1.0.0",
+			"artifacts": [
+				{
+					"url": "https://github.com/AwesomeTornado/ResoniteAprilFools/releases/download/v1.0.0/ResoniteAprilFools.dll",
+					"sha256": "f20617b752e62ce3a4cf3340be8551f7f776816f0c88694ed7f32cdc91ea9817"
+				}
+			]
+		}
+	}
+}
+

--- a/manifest/com.__Choco__/ResoniteAprilFools/info.json
+++ b/manifest/com.__Choco__/ResoniteAprilFools/info.json
@@ -5,6 +5,15 @@
 	"category": "Memes",
 	"sourceLocation": "https://github.com/AwesomeTornado/ResoniteAprilFools",
 	"versions": {
+		"1.0.1": {
+			"releaseUrl": "https://github.com/AwesomeTornado/ResoniteAprilFools/releases/tag/v1.0.1",
+			"artifacts": [
+				{
+					"url": "https://github.com/AwesomeTornado/ResoniteAprilFools/releases/download/v1.0.1/ResoniteAprilFools.dll",
+					"sha256": "e5a4461553cb4d6e750d79156b0919e5bb6506fe86eabefabae2fcc8e617f8c2"
+				}
+			]
+		},
 		"1.0.0": {
 			"releaseUrl": "https://github.com/AwesomeTornado/ResoniteAprilFools/releases/tag/v1.0.0",
 			"artifacts": [

--- a/manifest/com.__Choco__/ResoniteAprilFools/info.json
+++ b/manifest/com.__Choco__/ResoniteAprilFools/info.json
@@ -13,15 +13,6 @@
 					"sha256": "e5a4461553cb4d6e750d79156b0919e5bb6506fe86eabefabae2fcc8e617f8c2"
 				}
 			]
-		},
-		"1.0.0": {
-			"releaseUrl": "https://github.com/AwesomeTornado/ResoniteAprilFools/releases/tag/v1.0.0",
-			"artifacts": [
-				{
-					"url": "https://github.com/AwesomeTornado/ResoniteAprilFools/releases/download/v1.0.0/ResoniteAprilFools.dll",
-					"sha256": "f20617b752e62ce3a4cf3340be8551f7f776816f0c88694ed7f32cdc91ea9817"
-				}
-			]
 		}
 	}
 }


### PR DESCRIPTION
This is a dead simple mod that patches the engine check for April Fools content and always returns true.

- [x] The mod id matches the harmony id if used by the mod and starts with the same id as your author folder
- [x] All used links are valid
- [x] Your ResoniteMod.Version must match the version being added in the manifest and follow [Semantic Versioning](https://semver.org/)
- [x] Your AssemblyVersion should match the mod version
- [x] You have included an accurate `sha256` hash for each artifact
- [x] Do not remove old mods. Instead, use the `deprecated` flag
- [x] Follow the [Resonite Policies and Guidelines](https://resonite.com/policies/) and [Mod Submission Guidelines](https://github.com/resonite-modding-group/resonite-mod-manifest/wiki/Submission-Guidelines)
