### PR TITLE
Deprecate Banane9's BoundedUIX

### DIFF
--- a/manifest/Banane9/BoundedUIX/info.json
+++ b/manifest/Banane9/BoundedUIX/info.json
@@ -1,4 +1,5 @@
 {
+    "flags": ["deprecated"],
 	"name": "BoundedUIX",
 	"id": "Banane9.BoundedUIX",
 	"description": "Makes UIX elements selectable and editable with the usual Slot gizmos and fixes UIX elements breaking when a parent is inserted",


### PR DESCRIPTION
Add the deprecated flag because it was last updated in 2023 and won't be maintained because the newer version is for MonkeyLoader.