### PR TITLE
Update HostCrashGuard to V2.4.5

### DIFF
--- a/manifest/com.__Choco__/HostCrashGuard/info.json
+++ b/manifest/com.__Choco__/HostCrashGuard/info.json
@@ -5,6 +5,14 @@
 	"category": "Bug Workaround",
 	"sourceLocation": "https://github.com/AwesomeTornado/Resonite-HostCrashGuard",
 	"versions": {
+		"2.4.5": {
+			"releaseUrl": "https://github.com/AwesomeTornado/Resonite-HostCrashGuard/releases/tag/V2.4.5",
+			"artifacts": [{
+				"url": "https://github.com/AwesomeTornado/Resonite-HostCrashGuard/releases/download/V2.4.5/HostCrashGuard.dll",
+				"sha256": "5db26c4b3144caac23190727e1571193507b42c42a72b5f33b4de87e9361811d"
+			}],
+			"changelog": "Fixed component validation."
+		},
 		"2.4.0": {
 			"releaseUrl": "https://github.com/AwesomeTornado/Resonite-HostCrashGuard/releases/tag/V2.4.0",
 			"artifacts": [{


### PR DESCRIPTION
I accidentally introduced a bug in the previous version that flagged many valid component types as invalid. This release should fix that. More information can be found [here](https://github.com/AwesomeTornado/Resonite-HostCrashGuard/issues/10).

- [x] The mod id matches the harmony id if used by the mod and starts with the same id as your author folder
- [x] All used links are valid
- [x] Your ResoniteMod.Version must match the version being added in the manifest and follow [Semantic Versioning](https://semver.org/)
- [x] Your AssemblyVersion should match the mod version
- [x] You have included an accurate `sha256` hash for each artifact
- [x] Do not remove old mods. Instead, use the `deprecated` flag
- [x] Follow the [Resonite Policies and Guidelines](https://resonite.com/policies/) and [Mod Submission Guidelines](https://github.com/resonite-modding-group/resonite-mod-manifest/wiki/Submission-Guidelines)
