### PR TITLE
Add CustomShaderLib And DoublePrecision

### DIFF
--- a/manifest/com.__Choco__/CustomShaderLib/info.json
+++ b/manifest/com.__Choco__/CustomShaderLib/info.json
@@ -9,7 +9,7 @@
 			"releaseUrl": "https://github.com/AwesomeTornado/Resonite-CustomShaderLib/releases/tag/v1.0.1",
 			"artifacts": [
 				{
-					"url": "https://github.com/AwesomeTornado/Resonite-CustomShaderLib/releases/tag/v1.0.1/CustomShaderLib.dll",
+					"url": "https://github.com/AwesomeTornado/Resonite-CustomShaderLib/releases/download/v1.0.1/CustomShaderLib.dll",
 					"sha256": "113263b286d5e84fa3330dfb0eb4b475ec28c9cf38f9e6b5267c8eaf2fc546d0"
 				}
 			]

--- a/manifest/com.__Choco__/CustomShaderLib/info.json
+++ b/manifest/com.__Choco__/CustomShaderLib/info.json
@@ -1,0 +1,19 @@
+{
+	"name": "CustomShaderLib",
+	"id": "com.__Choco__.CustomShaderLib",
+	"description": "Removes shader validation and verification, in order to allow custom shaders.",
+	"category": "Libraries",
+	"sourceLocation": "https://github.com/AwesomeTornado/Resonite-CustomShaderLib",
+	"versions": {
+		"1.0.1": {
+			"releaseUrl": "https://github.com/AwesomeTornado/Resonite-CustomShaderLib/releases/tag/v1.0.1",
+			"artifacts": [
+				{
+					"url": "https://github.com/AwesomeTornado/Resonite-CustomShaderLib/releases/tag/v1.0.1/CustomShaderLib.dll",
+					"sha256": "113263b286d5e84fa3330dfb0eb4b475ec28c9cf38f9e6b5267c8eaf2fc546d0"
+				}
+			]
+		}
+	}
+}
+

--- a/manifest/com.__Choco__/DoublePrecision/info.json
+++ b/manifest/com.__Choco__/DoublePrecision/info.json
@@ -5,12 +5,12 @@
 	"category": "Visual Tweaks",
 	"sourceLocation": "https://github.com/AwesomeTornado/Resonite-DoublePrecision-RML",
 	"versions": {
-		"1.6.0": {
-			"releaseUrl": "https://github.com/AwesomeTornado/Resonite-DoublePrecision-RML/releases/tag/V1.6.0",
+		"1.6.1": {
+			"releaseUrl": "https://github.com/AwesomeTornado/Resonite-DoublePrecision-RML/releases/tag/V1.6.1",
 			"artifacts": [
 				{
-					"url": "https://github.com/AwesomeTornado/Resonite-DoublePrecision-RML/releases/download/V1.6.0/DoublePrecision.dll",
-					"sha256": "8e9a99cc9a583befcf408645bb98674a7ac2bd627f4b43f0f385e5d2d46d62be"
+					"url": "https://github.com/AwesomeTornado/Resonite-DoublePrecision-RML/releases/download/V1.6.1/DoublePrecision.dll",
+					"sha256": "f380b96ff4721e439d7eede80109223d76eb6436155962536c401a1b132dd6fb"
 				}
 			],
 			"dependencies": {

--- a/manifest/com.__Choco__/DoublePrecision/info.json
+++ b/manifest/com.__Choco__/DoublePrecision/info.json
@@ -6,7 +6,7 @@
 	"sourceLocation": "https://github.com/AwesomeTornado/Resonite-DoublePrecision-RML",
 	"versions": {
 		"1.6.0": {
-			"releaseUrl": "https://github.com/AwesomeTornado/Resonite-DoublePrecision-RML/tag/V1.6.0",
+			"releaseUrl": "https://github.com/AwesomeTornado/Resonite-DoublePrecision-RML/releases/tag/V1.6.0",
 			"artifacts": [
 				{
 					"url": "https://github.com/AwesomeTornado/Resonite-DoublePrecision-RML/releases/download/V1.6.0/DoublePrecision.dll",

--- a/manifest/com.__Choco__/DoublePrecision/info.json
+++ b/manifest/com.__Choco__/DoublePrecision/info.json
@@ -12,7 +12,12 @@
 					"url": "https://github.com/AwesomeTornado/Resonite-DoublePrecision-RML/releases/download/V1.6.0/DoublePrecision.dll",
 					"sha256": "8e9a99cc9a583befcf408645bb98674a7ac2bd627f4b43f0f385e5d2d46d62be"
 				}
-			]
+			],
+			"dependencies": {
+    				"com.__Choco__.CustomShaderLib": {
+        				"version": "1.0.1"
+    				}
+			}
 		}
 	}
 }

--- a/manifest/com.__Choco__/DoublePrecision/info.json
+++ b/manifest/com.__Choco__/DoublePrecision/info.json
@@ -1,0 +1,19 @@
+{
+	"name": "DoublePrecision",
+	"id": "com.__Choco__.DoublePrecision",
+	"description": "Fixes floating point rendering errors!",
+	"category": "Visual Tweaks",
+	"sourceLocation": "https://github.com/AwesomeTornado/Resonite-DoublePrecision-RML",
+	"versions": {
+		"1.6.0": {
+			"releaseUrl": "https://github.com/AwesomeTornado/Resonite-DoublePrecision-RML/tag/V1.6.0",
+			"artifacts": [
+				{
+					"url": "https://github.com/AwesomeTornado/Resonite-DoublePrecision-RML/releases/download/V1.6.0/DoublePrecision.dll",
+					"sha256": "8e9a99cc9a583befcf408645bb98674a7ac2bd627f4b43f0f385e5d2d46d62be"
+				}
+			]
+		}
+	}
+}
+


### PR DESCRIPTION
This PR adds in both CustomShaderLib, and DoublePrecision. While I believe that I have filled out the JSON correctly to add each mod, DoublePrecision relies on CustomShaderLib as a dependency and will break materials if used on its own. Is there any officially supported way to list dependencies, or should I just add CustomShaderLib as another artifact?

- [x] The mod id matches the harmony id if used by the mod and starts with the same id as your author folder
- [x] All used links are valid
- [x] Your ResoniteMod.Version must match the version being added in the manifest and follow [Semantic Versioning](https://semver.org/)
- [x] Your AssemblyVersion should match the mod version
- [x] You have included an accurate `sha256` hash for each artifact
- [x] Do not remove old mods. Instead, use the `deprecated` flag
- [x] Follow the [Resonite Policies and Guidelines](https://resonite.com/policies/) and [Mod Submission Guidelines](https://github.com/resonite-modding-group/resonite-mod-manifest/wiki/Submission-Guidelines)
