### PR TITLE
Add DynVarGenerator 1.3.4 and BoneReferenceHelper 2.0.5 

### DIFF
--- a/manifest/com.TheJebForge/BoneReferenceHelper/info.json
+++ b/manifest/com.TheJebForge/BoneReferenceHelper/info.json
@@ -1,0 +1,16 @@
+{
+	"name": "BoneReferenceHelper",
+	"id": "com.TheJebForge.BoneReferenceHelper",
+	"description": "Adds a lot of useful things for transferring bone references of skinned mesh renderers",
+	"category": "Inspectors",
+	"sourceLocation": "https://github.com/TheJebForge/BoneReferenceHelper",
+	"versions": {
+		"2.0.5": {
+			"releaseUrl": "https://github.com/TheJebForge/BoneReferenceHelper/releases/tag/v2.0.5",
+			"artifacts": [{
+				"url": "https://github.com/TheJebForge/BoneReferenceHelper/releases/download/v2.0.5/BoneReferenceHelper.dll",
+				"sha256": "203a14448c8b9fff31fee1b27c28e3cc139b660ed146854cff7696a31de8e861"
+			}]
+		}
+	}
+}

--- a/manifest/com.TheJebForge/DynVarGenerator/info.json
+++ b/manifest/com.TheJebForge/DynVarGenerator/info.json
@@ -1,0 +1,16 @@
+{
+	"name": "DynVarGenerator",
+	"id": "com.TheJebForge.DynVarGenerator",
+	"description": "Adds a wizard to quickly generate huge amounts of dynamic fields/variables/drivers for slots, blend shapes, bones or anything else",
+	"category": "Wizards",
+	"sourceLocation": "https://github.com/TheJebForge/DynVarGenerator",
+	"versions": {
+		"1.3.4": {
+			"releaseUrl": "https://github.com/TheJebForge/DynVarGenerator/releases/tag/1.3.4",
+			"artifacts": [{
+				"url": "https://github.com/TheJebForge/DynVarGenerator/releases/download/1.3.4/DynVarGenerator.dll",
+				"sha256": "837b436da5f72fe493fbd4ac12febbdc4ef1c0290315afca517e841efb7b8317"
+			}]
+		}
+	}
+}

--- a/manifest/com.TheJebForge/author.json
+++ b/manifest/com.TheJebForge/author.json
@@ -1,0 +1,9 @@
+{
+	"author": {
+		"TheJebForge": {
+			"url": "https://github.com/TheJebForge",
+			"icon": "https://github.com/TheJebForge.png",
+			"website": "https://thejebforge.com/"
+		}
+	}
+}


### PR DESCRIPTION
Updated my mods to splittening and decided to get on manifest, since Resolute sure is handy

<!-- This template is provided for your convenience: feel free to delete it from your PR -->
- [x] The mod id starts with the same id as the author folder (ie: "com.example.ExampleModName")
- [x] The harmony id matches the mod id if Harmony is used. (ie "Harmony harmony = new("com.example.ExampleModName"))
- [x] All used links are valid
- [x] Your `ResoniteMod.Version` must match the version being added in the manifest and follow [Semantic Versioning](https://semver.org/)
- [x] Your `AssemblyVersion` and `AssemblyFileVersion` match the mod version above
- [x] You have included an accurate `sha256` hash for each artifact
- [x] Do not remove old mods. Instead, use the `deprecated` flag
- [x] Follow the [Resonite Policies and Guidelines](https://resonite.com/policies/) and [Mod Submission Guidelines](https://github.com/resonite-modding-group/resonite-mod-manifest/wiki/Submission-Guidelines)

If you are unsure on any of these steps, read the [Mod Submission](https://github.com/resonite-modding-group/resonite-mod-manifest/wiki/Mod-Submission) page on the wiki for more information or ask in discord.
