### PR TITLE
Update VDFaceTracking 1.1.3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -681,7 +681,7 @@
                 },
                 "com.__Choco__.ResoniteMP3": {
                     "category": "Asset Importing",
-                    "description": "Usually, resonite imports MP3 files as videos. This mod auto converts MP3 files into WAV files on import so that they import as audio files.",
+                    "description": "Usually, resonite imports MP3 files as videos. This mod auto converts MP3 files into OGG files on import so that they import as audio files.",
                     "name": "ResoniteMP3",
                     "sourceLocation": "https://github.com/AwesomeTornado/ResoniteMP3",
                     "versions": {
@@ -732,6 +732,25 @@
                                 }
                             ],
                             "releaseUrl": "https://github.com/AwesomeTornado/ResoniteMP3/releases/tag/V2.1.0"
+                        },
+                        "3.0.0": {
+                            "artifacts": [
+                                {
+                                    "sha256": "2f3787c38c8338c48364224453e76a736982e60f7f26cf654b72c50b39264aa9",
+                                    "url": "https://github.com/AwesomeTornado/ResoniteMP3/releases/download/V3.0.0/ResoniteMP3.dll"
+                                },
+                                {
+                                    "installLocation": "/rml_libs",
+                                    "sha256": "8065e8a1ae74db282723e0e53faa56410c867e9b41df7e835f54cf1e9807acc1",
+                                    "url": "https://github.com/AwesomeTornado/ResoniteMP3/releases/download/V3.0.0/FFMpegCore.dll"
+                                },
+                                {
+                                    "installLocation": "/rml_libs",
+                                    "sha256": "2c196e02ca9bc8d9b2aea7506014636e48868e180b0f54f7ff0ad520963588bf",
+                                    "url": "https://github.com/AwesomeTornado/ResoniteMP3/releases/download/V3.0.0/Instances.dll"
+                                }
+                            ],
+                            "releaseUrl": "https://github.com/AwesomeTornado/ResoniteMP3/releases/tag/V3.0.0"
                         }
                     }
                 }

--- a/manifest/org.zeith/VDFaceTracking/info.json
+++ b/manifest/org.zeith/VDFaceTracking/info.json
@@ -5,6 +5,13 @@
 	"category": "Hardware Integration",
 	"sourceLocation": "https://github.com/Zeitheron/VDFaceTracking",
 	"versions": {
+		"1.1.2": {
+			"releaseUrl": "https://github.com/Zeitheron/VDFaceTracking/releases/tag/1.1.2",
+			"artifacts": [{
+				"url": "https://github.com/Zeitheron/VDFaceTracking/releases/download/1.1.2/VDFaceTracking.dll",
+				"sha256": "f8bfa3cfba5b8ed38e2d9a69a0875f50acdc643a2d6275316cdcef7dac00afe7"
+			}]
+		},
 		"1.1.1": {
 			"releaseUrl": "https://github.com/Zeitheron/VDFaceTracking/releases/tag/1.1.1",
 			"artifacts": [{

--- a/manifest/org.zeith/VDFaceTracking/info.json
+++ b/manifest/org.zeith/VDFaceTracking/info.json
@@ -9,7 +9,7 @@
 			"releaseUrl": "https://github.com/Zeitheron/VDFaceTracking/releases/tag/1.1.2",
 			"artifacts": [{
 				"url": "https://github.com/Zeitheron/VDFaceTracking/releases/download/1.1.2/VDFaceTracking.dll",
-				"sha256": "f8bfa3cfba5b8ed38e2d9a69a0875f50acdc643a2d6275316cdcef7dac00afe7"
+				"sha256": "f689c8389ca8f8b78d5178fc8e0bec9dc5458f8a9740e4eade3445405c3a44d6"
 			}]
 		},
 		"1.1.1": {

--- a/manifest/org.zeith/VDFaceTracking/info.json
+++ b/manifest/org.zeith/VDFaceTracking/info.json
@@ -5,6 +5,13 @@
 	"category": "Hardware Integration",
 	"sourceLocation": "https://github.com/Zeitheron/VDFaceTracking",
 	"versions": {
+		"1.1.3": {
+			"releaseUrl": "https://github.com/Zeitheron/VDFaceTracking/releases/tag/1.1.3",
+			"artifacts": [{
+				"url": "https://github.com/Zeitheron/VDFaceTracking/releases/download/1.1.3/VDFaceTracking.dll",
+				"sha256": "cb0b2856a27099b895bbb8c750c08bc345d12595f1400bd6e0b0166d81064650"
+			}]
+		},
 		"1.1.2": {
 			"releaseUrl": "https://github.com/Zeitheron/VDFaceTracking/releases/tag/1.1.2",
 			"artifacts": [{


### PR DESCRIPTION
Hotfix another issue caused from .net 9, making Resonite fail to shutdown properly.