### PR TITLE
Add ResonitePSVR2 1.0.1

### DIFF
--- a/manifest/com.tabbynet/ResonitePSVR2/info.json
+++ b/manifest/com.tabbynet/ResonitePSVR2/info.json
@@ -1,0 +1,21 @@
+{
+	"name": "ResonitePSVR2",
+	"id": "com.tabbynet.ResonitePSVR2",
+	"description": "Enables support for special hardware features on the PlayStation VR2",
+	"category": "Hardware Integration",
+	"sourceLocation": "https://github.com/tabithamoon/ResonitePSVR2",
+	"versions": {
+		"1.0.1": {
+			"releaseUrl": "https://github.com/tabithamoon/ResonitePSVR2/releases/tag/v1.0.1",
+			"artifacts": [{
+				"url": "https://github.com/tabithamoon/ResonitePSVR2/releases/download/v1.0.1/ResonitePSVR2.dll",
+				"sha256": "58510374a69c30902c0351b07fcbec3d1c4d889906fc5098628fa48499625c7b"
+			}]
+		}
+	},
+        "tags": [
+            "psvr2",
+            "eye",
+            "tracking"
+        ]
+}

--- a/manifest/com.tabbynet/author.json
+++ b/manifest/com.tabbynet/author.json
@@ -1,0 +1,8 @@
+{
+	"author": {
+		"tabithamoon": {
+			"url": "https://github.com/tabithamoon",
+                        "website": "https://tabby.page"
+		}
+	}
+}


### PR DESCRIPTION
Adding my hardware enablement mod for easier install and more visibility for PS VR2 owners!
- [x] The mod id starts with the same id as the author folder (ie: "com.example.ExampleModName")
- [x] The harmony id matches the mod id if Harmony is used. (ie "Harmony harmony = new("com.example.ExampleModName"))
- [x] All used links are valid
- [x] Your `ResoniteMod.Version` must match the version being added in the manifest and follow [Semantic Versioning](https://semver.org/)
- [x] Your `AssemblyVersion` and `AssemblyFileVersion` match the mod version above
- [x] You have included an accurate `sha256` hash for each artifact
- [x] Do not remove old mods. Instead, use the `deprecated` flag
- [x] Follow the [Resonite Policies and Guidelines](https://resonite.com/policies/) and [Mod Submission Guidelines](https://github.com/resonite-modding-group/resonite-mod-manifest/wiki/Submission-Guidelines)