### PR TITLE
Deprecate SimpleInventorySearch, DynBoneWrangler, NoDoubleTapSprint, ColourMyFiles

### DIFF
--- a/manifest/ch.isota/DynBoneWrangler/info.json
+++ b/manifest/ch.isota/DynBoneWrangler/info.json
@@ -4,6 +4,9 @@
 	"description": "Stops DynamicBoneChain components from updating (locally) if your framerate is too low to properly simulate them.",
 	"category": "Optimization",
 	"sourceLocation": "https://github.com/isovel/DynBoneWrangler",
+	"flags": [
+	"deprecated"
+	],
 	"versions": {
 		"1.0.1": {
 			"releaseUrl": "https://github.com/isovel/DynBoneWrangler/releases/tag/v1.0.1",

--- a/manifest/com.Kannya/ColourMyFiles/info.json
+++ b/manifest/com.Kannya/ColourMyFiles/info.json
@@ -4,6 +4,9 @@
     "description": "Simply colours your files in the files window on a per file category basis in Resonite. Configurable.",
     "category": "Dashboard",
     "sourceLocation": "https://github.com/KannyaResonite/ColourMyFiles",
+	"flags": [
+	"deprecated"
+	],
     "versions": {
         "1.0.0": {
             "releaseUrl": "https://github.com/KannyaResonite/ColourMyFiles/releases/tag/1.0.0",

--- a/manifest/me.art0007i/SimpleInventorySearch/info.json
+++ b/manifest/me.art0007i/SimpleInventorySearch/info.json
@@ -4,6 +4,9 @@
     "description": "Adds a filter bar which filters the currently open folder.",
     "category": "Dashboard",
     "sourceLocation": "https://github.com/art0007i/SimpleInventorySearch",
+	"flags": [
+	"deprecated"
+	],
     "versions": {
         "1.0.0": {
             "releaseUrl": "https://github.com/art0007i/SimpleInventorySearch/releases/tag/1.0.0",

--- a/manifest/semmiedev/NoDoubleTapSprint/info.json
+++ b/manifest/semmiedev/NoDoubleTapSprint/info.json
@@ -4,6 +4,9 @@
 	"description": "Disable double-tap sprinting when using a keyboard",
 	"category": "Controls",
 	"sourceLocation": "https://github.com/SemmieDev/NoDoubleTapSprint",
+	"flags": [
+	"deprecated"
+	],
 	"versions": {
 		"1.0.0": {
 			"releaseUrl": "https://github.com/SemmieDev/NoDoubleTapSprint/releases/tag/v1.0.0",


### PR DESCRIPTION
Deprecate 4 mods:
- SimpleInventorySearch (causes random crashes according to logs), 
- DynBoneWrangler (stops Resonite from loading), 
- NoDoubleTapSprint (breaks desktop locomotion), 
- ColourMyFiles (doesn't do anything anymore)