### PR TITLE
Deprecate ResoniteStopDisappearingLocomotionMenu

### DIFF
--- a/manifest/Banane9/StopDisappearingLocomotionMenu/info.json
+++ b/manifest/Banane9/StopDisappearingLocomotionMenu/info.json
@@ -4,6 +4,7 @@
 	"description": "Stops the locomotion (and scale) context menu entries from disappearing when a tool is equipped",
 	"category": "Context Menu",
 	"sourceLocation": "https://github.com/Banane9/ResoniteStopDisappearingLocomotionMenu",
+	"flags": ["deprecated"],
 	"versions": {
 		"1.0.0": {
 			"releaseUrl": "https://github.com/Banane9/ResoniteStopDisappearingLocomotionMenu/releases/tag/v1.0.0",


### PR DESCRIPTION
Broken on .NET 9 and won't be fixed.

By the way, sctanf has made a [fork](https://github.com/sctanf/ResoniteStopDisappearingLocomotionMenu) but the functionality of this mod is included in ML's GamePack so I'm not sure if it's worth even adding it to the manifest.