### PR TITLE
Deprecate MyInspectors

### DIFF
--- a/manifest/me.art0007i/MyInspectors/info.json
+++ b/manifest/me.art0007i/MyInspectors/info.json
@@ -48,5 +48,8 @@
     "id": "me.art0007i.MyInspectors",
     "description": "Makes inspectors generate by local user instead of host. Slightly unsable, if anything with inspectors breaks remove this mod.",
     "category": "Inspectors",
-    "sourceLocation": "https://github.com/art0007i/MyInspectors"
+    "sourceLocation": "https://github.com/art0007i/MyInspectors",
+    "flags": [
+		"deprecated"
+	]
 }


### PR DESCRIPTION
Mod is currently broken and causing problems in sessions.

Deprecating the mod hides it in Resolute by default. People who already have it will see it highlighted in red I think.

It can be un-deprecated if/when it gets fixed.