### PR TITLE
change WebHook Name to RML Mod Verifications

### DIFF
--- a/generate_notification.py
+++ b/generate_notification.py
@@ -145,7 +145,7 @@ for author_guid in NEW_MANIFEST["objects"]:
 if EMBEDS:
     DISCORD_JSON = {
         "embeds": EMBEDS,
-        "username": "Resonite Mod Verifications",
+        "username": "RML Mod Verifications",
         "avatar_url": "https://github.com/resonite-modding-group.png"
     }
 


### PR DESCRIPTION
Currently the WebHook announce messages have their user name as `Resonite Mod Verifications` I propose we change this to `RML Mod Verifications`. This repo only contains RML mods & libraries, this change makes that more clear.