### PR TITLE
Add tags and dependency for CustomProtofluxBrowser

### DIFF
--- a/manifest/co.uk.AlexW-578/CustomProtofluxBrowser/info.json
+++ b/manifest/co.uk.AlexW-578/CustomProtofluxBrowser/info.json
@@ -4,9 +4,18 @@
 	"description": "Allows you to use a custom protoflux browser by saving and favoriting it in your inventory.",
 	"category": "Protoflux",
 	"sourceLocation": "https://github.com/AlexW-578/CustomProtofluxBrowser",
+	"tags": [
+		"node",
+		"favorite"
+	],
 	"versions": {
 		"2.1.2": {
 			"releaseUrl": "https://github.com/AlexW-578/CustomProtofluxBrowser/releases/tag/v2.1.2",
+			"dependencies": {
+				"me.art0007i.SpecialItemsLib": {
+					"version": "^2.0.2"
+				}
+			},
 			"artifacts": [
 				{
 					"url": "https://github.com/AlexW-578/CustomProtofluxBrowser/releases/download/v2.1.2/CustomProtofluxBrowser.dll",
@@ -16,6 +25,11 @@
 		},
 		"2.1.3": {
 			"releaseUrl": "https://github.com/AlexW-578/CustomProtofluxBrowser/releases/tag/v2.1.3",
+			"dependencies": {
+				"me.art0007i.SpecialItemsLib": {
+					"version": "^2.0.3"
+				}
+			},
 			"artifacts": [
 				{
 					"url": "https://github.com/AlexW-578/CustomProtofluxBrowser/releases/download/v2.1.3/CustomProtofluxBrowser.dll",


### PR DESCRIPTION
Adds SpecialItemsLib as a dependency as it is required to work, also adds 2 tags to assist in search