### PR TITLE
Add MoreReferenceProxies 1.0.1

### DIFF
--- a/manifest/com.GrandtheUK/MoreReferenceProxies/info.json
+++ b/manifest/com.GrandtheUK/MoreReferenceProxies/info.json
@@ -15,13 +15,6 @@
 			]
 		}
 	},
-	"tags": [
-		"Bags",
-        "More",
-        "Reference",
-        "Proxies",
-        "Inspector"
-	],
     "additionalAuthors": [
         "EIA485"
     ]

--- a/manifest/com.GrandtheUK/MoreReferenceProxies/info.json
+++ b/manifest/com.GrandtheUK/MoreReferenceProxies/info.json
@@ -1,0 +1,28 @@
+{
+	"name": "MoreReferenceProxies",
+	"id": "com.GrandtheUK.MoreReferenceProxies",
+	"description": "An RML fork of the BepisLoader mod MoreReferenceProxies by EIA485 to add reference proxy source to bag editors and user inspector",
+	"category": "Inspectors",
+	"sourceLocation": "https://github.com/GrandtheUK/MoreReferenceProxies",
+	"versions": {
+		"1.0.1": {
+			"releaseUrl": "https://github.com/GrandtheUK/MoreReferenceProxies/releases/tag/v1.0.1",
+			"artifacts": [
+				{
+					"url": "https://github.com/GrandtheUK/MoreReferenceProxies/releases/download/v1.0.1/MoreReferenceProxies.dll",
+					"sha256": "736a2016413f3b2f4c2db1d2d26468c7c0b8e2c34dffca61b5ee4f02f1adf54e"
+				}
+			]
+		}
+	},
+	"tags": [
+		"Bags",
+        "More",
+        "Reference",
+        "Proxies",
+        "Inspector"
+	],
+    "additionalAuthors": [
+        "EIA485"
+    ]
+}


### PR DESCRIPTION
- [x] The mod id starts with the same id as the author folder (ie: "com.example.ExampleModName")
- [x] The harmony id matches the mod id if Harmony is used. (ie "Harmony harmony = new("com.example.ExampleModName"))
- [x] All used links are valid
- [x] Your `ResoniteMod.Version` must match the version being added in the manifest and follow [Semantic Versioning](https://semver.org/)
- [x] Your `AssemblyVersion` and `AssemblyFileVersion` match the mod version above
- [x] You have included an accurate `sha256` hash for each artifact
- [x] Do not remove old mods. Instead, use the `deprecated` flag
- [x] Follow the [Resonite Policies and Guidelines](https://resonite.com/policies/) and [Mod Submission Guidelines](https://github.com/resonite-modding-group/resonite-mod-manifest/wiki/Submission-Guidelines)

I have also added @EIA485 as an additionalAuthor as they are the original author of the HarmonyPatch used in this port.