### PR TITLE
Update CyberFingerMod 1.1.2

### DIFF
--- a/manifest/com.scicortex/CyberFingerMod/info.json
+++ b/manifest/com.scicortex/CyberFingerMod/info.json
@@ -32,7 +32,7 @@
 			}]
 		},
 		"1.1.2": {
-			"releaseUrl": "https://github.com/DrSciCortex/CyberFingerMod/releases/tag/v1.1.2",
+			"releaseUrl": "https://github.com/DrSciCortex/CyberFingerMod/releases/tag/1.1.2",
 			"artifacts": [{
 				"url": "https://github.com/DrSciCortex/CyberFingerMod/releases/download/1.1.2/CyberFingerMod.dll",
 				"sha256": "4a666db73be9b0a2539e00da71abb09810cde629b4ed82de2c056cf6ff0e72e9"


### PR DESCRIPTION
..., and github repo migration fixing link to original ExampleMod template. Previous versions are no longer available for download but remain defined.

<!-- This template is provided for your convenience: feel free to delete it from your PR -->
- [x] The mod id starts with the same id as the author folder (ie: "com.example.ExampleModName")
- [x] The harmony id matches the mod id if Harmony is used. (ie "Harmony harmony = new("com.example.ExampleModName"))
- [x] All used links are valid (but not old ones ... as discussed on discord)
- [x] Your `ResoniteMod.Version` must match the version being added in the manifest and follow [Semantic Versioning](https://semver.org/)
- [x] Your `AssemblyVersion` and `AssemblyFileVersion` match the mod version above
- [x] You have included an accurate `sha256` hash for each artifact
- [x] Do not remove old mods. Instead, use the `deprecated` flag (Question: where is the depricated flag?)
- [x] Follow the [Resonite Policies and Guidelines](https://resonite.com/policies/) and [Mod Submission Guidelines](https://github.com/resonite-modding-group/resonite-mod-manifest/wiki/Submission-Guidelines)

If you are unsure on any of these steps, read the [Mod Submission](https://github.com/resonite-modding-group/resonite-mod-manifest/wiki/Mod-Submission) page on the wiki for more information or ask in discord.
