### PR TITLE
Update ProtoFluxOverhaul 1.4.9 and 1.5.0

### DIFF
--- a/manifest/com.Dexy/ProtoFluxOverhaul/info.json
+++ b/manifest/com.Dexy/ProtoFluxOverhaul/info.json
@@ -50,18 +50,18 @@
 		"1.4.9": {
 			"releaseUrl": "https://github.com/DexyThePuppy/ProtoFluxOverhaul/releases/tag/1.4.9",
 			"artifacts": [{
-				"url": "https://github.com/DexyThePuppy/ProtoFluxOverhaul/releases/download/1.4.9/ProtoFluxOverhaul.dll",
-				"sha256": "9fa4b13e470934996e4622e5871539953341f741a62dd8480344204987a54d03"
+			"url": "https://github.com/DexyThePuppy/ProtoFluxOverhaul/releases/download/1.4.9/ProtoFluxOverhaul.dll",
+			"sha256": "9fa4b13e470934996e4622e5871539953341f741a62dd8480344204987a54d03"
 			}],
 			"changelog": "Fixes and sprite changes"
 		},
 		"1.5.0": {
 			"releaseUrl": "https://github.com/DexyThePuppy/ProtoFluxOverhaul/releases/tag/1.5.0",
 			"artifacts": [{
-				"url": "https://github.com/DexyThePuppy/ProtoFluxOverhaul/releases/download/1.5.0/ProtoFluxOverhaul.dll",
-				"sha256": "49c4b49b886e3929795241b30f05a04a8a56f439f3f98a1009889183ee08afc7"
+			"url": "https://github.com/DexyThePuppy/ProtoFluxOverhaul/releases/download/1.5.0/ProtoFluxOverhaul.dll",
+			"sha256": "49c4b49b886e3929795241b30f05a04a8a56f439f3f98a1009889183ee08afc7"
 			}],
 			"changelog": "Fixed permission issues"
-		},
+		}
 	}
 }


### PR DESCRIPTION
<!-- This template is provided for your convenience: feel free to delete it from your PR -->
- [x] The mod id starts with the same id as the author folder (ie: "com.example.ExampleModName")
- [x] The harmony id matches the mod id if Harmony is used. (ie "Harmony harmony = new("com.example.ExampleModName"))
- [x] All used links are valid
- [x] Your `ResoniteMod.Version` must match the version being added in the manifest and follow [Semantic Versioning](https://semver.org/)
- [x] Your `AssemblyVersion` and `AssemblyFileVersion` match the mod version above
- [x] You have included an accurate `sha256` hash for each artifact
- [x] Do not remove old mods. Instead, use the `deprecated` flag
- [x] Follow the [Resonite Policies and Guidelines](https://resonite.com/policies/) and [Mod Submission Guidelines](https://github.com/resonite-modding-group/resonite-mod-manifest/wiki/Submission-Guidelines)

How did I miss adding all versions since 1.4.2?