### PR TITLE
Deprecate ResoniteLinuxClipboard

### DIFF
--- a/manifest/com.GrandtheUK/ResoniteLinuxClipboard/info.json
+++ b/manifest/com.GrandtheUK/ResoniteLinuxClipboard/info.json
@@ -4,6 +4,7 @@
 	"description": "A mod that implements copy and paste in resonite for Text, Images and other files on Wayland",
 	"category": "Bug Workaround",
 	"sourceLocation": "https://github.com/GrandtheUK/ResoniteLinuxClipboard",
+	"flags": ["deprecated"],
 	"versions": {
 		"1.0.0": {
 			"releaseUrl": "https://github.com/GrandtheUK/ResoniteLinuxClipboard/releases/tag/v1.0.0",


### PR DESCRIPTION
<!-- This template is provided for your convenience: feel free to delete it from your PR -->
- [x] The mod id starts with the same id as the author folder (ie: "com.example.ExampleModName")
- [x] The harmony id matches the mod id if Harmony is used. (ie "Harmony harmony = new("com.example.ExampleModName"))
- [x] All used links are valid
- [x] Your `ResoniteMod.Version` must match the version being added in the manifest and follow [Semantic Versioning](https://semver.org/)
- [x] Your `AssemblyVersion` and `AssemblyFileVersion` match the mod version above
- [x] You have included an accurate `sha256` hash for each artifact
- [x] Do not remove old mods. Instead, use the `deprecated` flag
- [x] Follow the [Resonite Policies and Guidelines](https://resonite.com/policies/) and [Mod Submission Guidelines](https://github.com/resonite-modding-group/resonite-mod-manifest/wiki/Submission-Guidelines)

If you are unsure on any of these steps, read the [Mod Submission](https://github.com/resonite-modding-group/resonite-mod-manifest/wiki/Mod-Submission) page on the wiki for more information or ask in discord.
