### PR TITLE
Update CherryTypes 1.0.2

### DIFF
--- a/manifest/cat.colin/CherryTypes/info.json
+++ b/manifest/cat.colin/CherryTypes/info.json
@@ -6,6 +6,16 @@
   "sourceLocation": "https://github.com/ColinTimBarndt/resonite-cherry-types-mod",
   "tags": ["inspector", "component", "favorite", "favourite", "ProtoFlux"],
   "versions": {
+    "1.0.2": {
+      "releaseUrl": "https://github.com/ColinTimBarndt/resonite-cherry-types-mod/releases/tag/v1.0.2",
+      "artifacts": [
+        {
+          "url": "https://github.com/ColinTimBarndt/resonite-cherry-types-mod/releases/download/v1.0.2/CherryTypes.dll",
+          "sha256": "85449d3a464187af8711b61e969e50c1672ce66bad961c53ff20318bb8b69bc4"
+        }
+      ],
+      "changelog": "Changed how the mod initializes to fix a potential issue."
+    },
     "1.0.1": {
       "releaseUrl": "https://github.com/ColinTimBarndt/resonite-cherry-types-mod/releases/tag/v1.0.1",
       "artifacts": [


### PR DESCRIPTION
<!-- This template is provided for your convenience: feel free to delete it from your PR -->
- [x] The mod id starts with the same id as the author folder (ie: "com.example.ExampleModName")
- [x] The harmony id matches the mod id if Harmony is used. (ie "Harmony harmony = new("com.example.ExampleModName"))
- [x] All used links are valid
- [x] Your `ResoniteMod.Version` must match the version being added in the manifest and follow [Semantic Versioning](https://semver.org/)
- [x] Your `AssemblyVersion` and `AssemblyFileVersion` match the mod version above
- [x] You have included an accurate `sha256` hash for each artifact
- [x] Do not remove old mods. Instead, use the `deprecated` flag
- [x] Follow the [Resonite Policies and Guidelines](https://resonite.com/policies/) and [Mod Submission Guidelines](https://github.com/resonite-modding-group/resonite-mod-manifest/wiki/Submission-Guidelines)

I've set up this mod with build attestation such that the DLL can be verified that it was built from a GH action from the given source: `gh attestation verify CherryTypes.dll -R ColinTimBarndt/resonite-cherry-types-mod`. Perhaps such a setup could be used to improve the manifest verification process in the future.