### PR TITLE
Fixup BC7EncMod bc7enc.NET dependency

### DIFF
--- a/manifest/org.yosh/BC7EncMod/info.json
+++ b/manifest/org.yosh/BC7EncMod/info.json
@@ -13,8 +13,8 @@
 					"sha256": "6aec143c8cffe53bb8358767481e44d8d0010a7eb49159bcfbe93a9653915e8b"
 				},
 				{
-					"url": "https://git.unix.dog/yosh/bc7enc.NET/releases/download/v0.2.0/bc7enc.NET.dll",
-					"sha256": "e8e24ed994f5cfb9e540833258def3be33ad15b81fa996fabd6df27035cc6c11",
+					"url": "https://git.unix.dog/yosh/bc7enc.NET/releases/download/v0.2.1/bc7enc.NET.dll",
+					"sha256": "c65a5278891f755baefb4840bf5d2809d988dc41ddf796edd1008fc6c2ada82d",
 					"installLocation": "/rml_libs"
 				},
 				{


### PR DESCRIPTION
No functional changes, just fixing the file version in the library, so a mod update isn't necessary.