### PR TITLE
Add DesktopBuddy

### DIFF
--- a/DevL0rd/DesktopBuddy/info.json
+++ b/DevL0rd/DesktopBuddy/info.json
@@ -1,7 +1,7 @@
 {
   "name": "DesktopBuddy",
   "id": "com.devl0rd.DesktopBuddy",
-  "description": "Super early access desktop/window viewer with touch input, GPU capture, and streaming to other users via Cloudflare Tunnel. Windows and NVIDIA GPU only for the moment. If streaming doesn't work, run as admin: netsh http add urlacl url=http://+:48080/ user=Everyone",
+  "description": "Super early access desktop/window viewer with touch input, GPU capture, and streaming to other users via Cloudflare Tunnel. Windows and NVIDIA GPU only for the moment. If streaming doesn't work, run as admin: netsh http add urlacl url=http://+:48080/ sddl=D:(A;;GX;;;S-1-1-0)",
   "category": "Misc",
   "sourceLocation": "https://github.com/DevL0rd/DesktopBuddy",
   "platforms": ["windows"],

--- a/DevL0rd/DesktopBuddy/info.json
+++ b/DevL0rd/DesktopBuddy/info.json
@@ -1,7 +1,7 @@
 {
   "name": "DesktopBuddy",
   "id": "com.devl0rd.DesktopBuddy",
-  "description": "Super early access desktop/window viewer with touch input, GPU capture, and streaming to other users via Cloudflare Tunnel. Windows and NVIDIA GPU only for the moment. If streaming doesn't work, run as admin: netsh http add urlacl url=http://+:48080/ sddl=D:(A;;GX;;;S-1-1-0)",
+  "description": "Super early access desktop/window viewer with touch input, GPU capture, and streaming to other users via Cloudflare Tunnel. Windows and NVIDIA GPU only for the moment. If streaming doesn't work, run as admin: netsh http add urlacl url=http://+:48080/ sddl=\"D:(A;;GX;;;S-1-1-0)\"",
   "category": "Misc",
   "sourceLocation": "https://github.com/DevL0rd/DesktopBuddy",
   "platforms": ["windows"],

--- a/DevL0rd/DesktopBuddy/info.json
+++ b/DevL0rd/DesktopBuddy/info.json
@@ -1,0 +1,20 @@
+{
+  "name": "DesktopBuddy",
+  "id": "com.devl0rd.DesktopBuddy",
+  "description": "Super early access desktop/window viewer with touch input, GPU capture, and streaming to other users via Cloudflare Tunnel. Windows and NVIDIA GPU only for the moment. If streaming doesn't work, run as admin: netsh http add urlacl url=http://+:48080/ user=Everyone",
+  "category": "Misc",
+  "sourceLocation": "https://github.com/DevL0rd/DesktopBuddy",
+  "platforms": ["windows"],
+  "tags": ["desktop", "screen share", "streaming", "window capture"],
+  "versions": {
+    "1.0.0": {
+      "releaseUrl": "https://github.com/DevL0rd/DesktopBuddy/releases/tag/build-aaccf2a",
+      "artifacts": [
+        {
+          "url": "https://github.com/DevL0rd/DesktopBuddy/releases/download/build-aaccf2a/DesktopBuddy.zip",
+          "sha256": "47b2fc8d61212fb081b344368fa1e2e997a31935b054b6197d3bc5f8b8e136a0"
+        }
+      ]
+    }
+  }
+}

--- a/DevL0rd/author.json
+++ b/DevL0rd/author.json
@@ -1,0 +1,5 @@
+{
+  "Dustin": {
+    "url": "https://github.com/DevL0rd"
+  }
+}


### PR DESCRIPTION
Adds DesktopBuddy - desktop/window viewer mod for Resonite.

GPU-accelerated window capture, hardware H.264 encoding, and streaming to other users via Cloudflare Tunnel. Windows only, requires NVIDIA GPU.

Source: https://github.com/DevL0rd/DesktopBuddy

- [ ] The mod id starts with the same id as the author folder (ie: "com.example.ExampleModName")
- [ ] The harmony id matches the mod id if Harmony is used. (ie "Harmony harmony = new("com.example.ExampleModName"))
- [x] All used links are valid
- [x] Your `ResoniteMod.Version` must match the version being added in the manifest and follow [Semantic Versioning](https://semver.org/)
- [x] Your `AssemblyVersion` and `AssemblyFileVersion` match the mod version above
- [x] You have included an accurate `sha256` hash for each artifact
- [x] Do not remove old mods. Instead, use the `deprecated` flag
- [ ] Follow the [Resonite Policies and Guidelines](https://resonite.com/policies/) and [Mod Submission Guidelines](https://github.com/resonite-modding-group/resonite-mod-manifest/wiki/Submission-Guidelines)