### PR TITLE
Update BC7EncMod 1.2.3

### DIFF
--- a/manifest/org.yosh/BC7EncMod/info.json
+++ b/manifest/org.yosh/BC7EncMod/info.json
@@ -5,6 +5,30 @@
 	"category": "Technical Tweaks",
 	"sourceLocation": "https://git.unix.dog/yosh/ResoniteBC7EncMod",
 	"versions": {
+		"1.2.3": {
+			"releaseUrl": "https://git.unix.dog/yosh/ResoniteBC7EncMod/releases/tag/v1.2.3",
+			"artifacts": [
+				{
+					"url": "https://git.unix.dog/yosh/ResoniteBC7EncMod/releases/download/v1.2.3/BC7EncMod.dll",
+					"sha256": "71301637fff29f5fa502b06a3d3abd75538335ca58409038aebab7b3a413d470"
+				},
+				{
+					"url": "https://git.unix.dog/yosh/bc7enc.NET/releases/download/v0.2.1/bc7enc.NET.dll",
+					"sha256": "c65a5278891f755baefb4840bf5d2809d988dc41ddf796edd1008fc6c2ada82d",
+					"installLocation": "/rml_libs"
+				},
+				{
+					"url": "https://git.unix.dog/yosh/bc7enc_rdo_ffi/releases/download/v0.2.0/bc7enc.dll",
+					"sha256": "e85d35c0319260b00425cf23f9e01de17be5e82a13a494877b07390adccec3ad",
+					"installLocation": "/rml_libs"
+				},
+				{
+					"url": "https://git.unix.dog/yosh/bc7enc_rdo_ffi/releases/download/v0.2.0/libbc7enc.so",
+					"sha256": "7cf28802f726517f8d7d4f839846b98377b438e976e185951eeee78710670943",
+					"installLocation": "/rml_libs"
+				}
+			]
+		},
 		"1.2.2": {
 			"releaseUrl": "https://git.unix.dog/yosh/ResoniteBC7EncMod/releases/tag/v1.2.2",
 			"artifacts": [


### PR DESCRIPTION
during making v1.2.2, I was experimenting with adding thread limiting to bc7enc.NET & the mod, but backed out halfway through. the remnant of this is that v1.2.2 relies on bc7enc.NET 0.3.0 as I forgot to re-compile after backing out. this, obviously, makes encoding not work at all.

this fixes that.