### PR TITLE
feat(org.Kayt): add CustomInspectorFonts mod v1.2.0

### DIFF
--- a/manifest/org.Kayt/CustomInspectorFonts/info.json
+++ b/manifest/org.Kayt/CustomInspectorFonts/info.json
@@ -1,0 +1,16 @@
+{
+	"name": "CustomInspectorFonts",
+	"id": "org.Kayt.CustomInspectorFonts",
+	"description": "Change the font used in Resonite's inspector panels and developer UI to whatever you want using a FontChain component on your avatar.",
+	"category": "Inspectors",
+	"sourceLocation": "https://github.com/jukefr/ResoniteCustomInspectorFonts",
+	"versions": {
+		"1.2.0": {
+			"releaseUrl": "https://github.com/jukefr/ResoniteCustomInspectorFonts/releases/tag/v1.2.0",
+			"artifacts": [{
+				"url": "https://github.com/jukefr/ResoniteCustomInspectorFonts/releases/download/v1.2.0/CustomInspectorFonts.dll",
+				"sha256": "8e766a64b967320a9837134ac0eafe31fd3a22a2f2265ebf11e1e32ddf04326c"
+			}]
+		}
+	}
+}

--- a/manifest/org.Kayt/author.json
+++ b/manifest/org.Kayt/author.json
@@ -1,0 +1,8 @@
+{
+	"author": {
+		"Kayt": {
+			"url": "https://github.com/jukefr",
+			"icon": "https://github.com/jukefr.png"
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add CustomInspectorFonts mod by Kayt (v1.2.0)

## Checklist
- [x] The mod id starts with the same id as the author folder (ie: "com.example.ExampleModName")
- [x] The harmony id matches the mod id if Harmony is used. (ie "Harmony harmony = new("com.example.ExampleModName"))
- [x] All used links are valid
- [x] Your `ResoniteMod.Version` must match the version being added in the manifest and follow [Semantic Versioning](https://semver.org/)
- [x] Your `AssemblyVersion` and `AssemblyFileVersion` match the mod version above
- [x] You have included an accurate `sha256` hash for each artifact
- [x] Do not remove old mods. Instead, use the `deprecated` flag
- [ ] Follow the [Resonite Policies and Guidelines](https://resonite.com/policies/) and [Mod Submission Guidelines](https://github.com/resonite-modding-group/resonite-mod-manifest/wiki/Submission-Guidelines)

## Details
- **Mod ID:** `org.Kayt.CustomInspectorFonts`
- **Harmony ID:** `org.Kayt.CustomInspectorFonts` (matches mod ID)
- **Category:** Inspectors
- **Version:** 1.2.0 (matches `<Version>1.2.0</Version>` in csproj)
- **SHA256:** from GitHub's auto-generated digest for the release asset