### PR TITLE
Add ReBlendshapes 1.0.0

### DIFF
--- a/manifest/com.Moonbase/ReBlendshapes/info.json
+++ b/manifest/com.Moonbase/ReBlendshapes/info.json
@@ -1,0 +1,19 @@
+{
+	"name": "ReBlendshapes",
+	"id": "com.Moonbase.ReBlendshapes",
+	"description": "A Mod That Makes Copying Blendshapes From Your Avatar To A Piece Of Clothing Or Accessory Easier",
+	"category": "Inspectors",
+	"sourceLocation": "https://github.com/Moonbasee/ReBlendshapes",
+	"versions": {
+		"1.0.0": {
+			"releaseUrl": "https://github.com/Moonbasee/ReBlendshapes/releases/tag/1.0.0",
+			"artifacts": [
+				{
+					"url": "https://github.com/Moonbasee/ReBlendshapes/releases/download/1.0.0/ReBlendshapes.dll",
+					"filename": "ReBlendshapes.dll",
+					"sha256": "09a960e0e0d30528b38c196a04c17f7f3cc882ad8358d2c4611d309c98d1cfa1"
+				}
+			]
+		}
+	}
+}

--- a/manifest/com.Moonbase/author.json
+++ b/manifest/com.Moonbase/author.json
@@ -1,0 +1,10 @@
+{
+	"author": {
+		"Moonbase__": {
+			"url": "https://github.com/Moonbasee",
+			"icon": "https://github.com/Moonbasee.png",
+			"support": "https://ko-fi.com/moonbase__",
+			"website": "https://furry.alanmoon.net"
+		}
+	}
+}


### PR DESCRIPTION
# What Is This?
This is a mod that makes copying blendshapes from your avatar to a piece of clothing or accessory easier.

# How Do I Use It?
On your avatars Body slot, scroll to the bottom of the SkinnedMeshRenderer and drop in the SkinnedMeshRenderer of the accessory or clothing into the "Skinned Mesh Renderer" field under the mod name.

# Why Is This Using The Same UI Code From Re-Armature?
I am not a UIX expert and ReBlendshapes was inspired by this mod. I have given credit to the original repo in the source code.

# Why Are The Commits Weird?
I accidentally pushed to the main branch without first making a new one. For cleanliness, I have corrected the mistake.