### PR TITLE
Add WorldOrbDynVars 1.0.2

### DIFF
--- a/manifest/net.dextraspace/WorldOrbDynVars/info.json
+++ b/manifest/net.dextraspace/WorldOrbDynVars/info.json
@@ -1,7 +1,7 @@
 {
 	"name": "WorldOrbDynVars",
-	"id": "com.dextraspace.WorldOrbDynVars",
-	"description": "A resonite mod to attach a DynamicVariableSpace to a child slot of WorldOrb components that relay info for them.",
+	"id": "net.dextraspace.WorldOrbDynVars",
+	"description": "A Resonite mod to attach a DynamicVariableSpace to a child slot of WorldOrb components that relay info for them.",
 	"category": "Technical Tweaks",
 	"sourceLocation": "https://github.com/Cyberboss/WorldOrbDynVars",
 	"versions": {
@@ -10,28 +10,12 @@
 			"artifacts": [{
 				"url": "https://github.com/Cyberboss/WorldOrbDynVars/releases/download/v1.0.2/WorldOrbDynVars.dll",
 				"sha256": "dc38bd8b75ba5772f7da0d0970efe38b182ae1ba8495512cd062103129c24737"
-			}],
-			"dependencies": {
-				"net.pardeike.harmony": {
-					"version": "^2.4.2"
-				}
-			}
+			}]
 		}
 	},
 	"tags": [
-        "world",
-        "orb",
-        "worldorb",
-        "worldorbs",
-		"orb",
-		"dynvar",
-		"dynvars",
-		"dyn",
-		"var",
-		"vars",
 		"dynamic",
 		"variable",
-		"variables",
 		"dynamicvariablespace"
     ]
 }

--- a/manifest/net.dextraspace/WorldOrbDynVars/info.json
+++ b/manifest/net.dextraspace/WorldOrbDynVars/info.json
@@ -1,7 +1,7 @@
 {
 	"name": "WorldOrbDynVars",
 	"id": "net.dextraspace.WorldOrbDynVars",
-	"description": "A Resonite mod to attach a DynamicVariableSpace to a child slot of WorldOrb components that relay info for them.",
+	"description": "A Resonite mod to attach a DynamicVariableSpace to a child slot of WorldOrb components that relays info for them.",
 	"category": "Technical Tweaks",
 	"sourceLocation": "https://github.com/Cyberboss/WorldOrbDynVars",
 	"versions": {

--- a/manifest/net.dextraspace/WorldOrbDynVars/info.json
+++ b/manifest/net.dextraspace/WorldOrbDynVars/info.json
@@ -1,0 +1,37 @@
+{
+	"name": "WorldOrbDynVars",
+	"id": "com.dextraspace.WorldOrbDynVars",
+	"description": "A resonite mod to attach a DynamicVariableSpace to a child slot of WorldOrb components that relay info for them.",
+	"category": "Technical Tweaks",
+	"sourceLocation": "https://github.com/Cyberboss/WorldOrbDynVars",
+	"versions": {
+		"1.0.2": {
+			"releaseUrl": "https://github.com/Cyberboss/WorldOrbDynVars/releases/tag/v1.0.2",
+			"artifacts": [{
+				"url": "https://github.com/Cyberboss/WorldOrbDynVars/releases/download/v1.0.2/WorldOrbDynVars.dll",
+				"sha256": "dc38bd8b75ba5772f7da0d0970efe38b182ae1ba8495512cd062103129c24737"
+			}],
+			"dependencies": {
+				"net.pardeike.harmony": {
+					"version": "^2.4.2"
+				}
+			}
+		}
+	},
+	"tags": [
+        "world",
+        "orb",
+        "worldorb",
+        "worldorbs",
+		"orb",
+		"dynvar",
+		"dynvars",
+		"dyn",
+		"var",
+		"vars",
+		"dynamic",
+		"variable",
+		"variables",
+		"dynamicvariablespace"
+    ]
+}

--- a/manifest/net.dextraspace/author.json
+++ b/manifest/net.dextraspace/author.json
@@ -1,6 +1,6 @@
 {
 	"author": {
-		"ExampleAuthor": {
+		"Dominion": {
 			"url": "https://github.com/Cyberboss",
 			"icon": "https://github.com/Cyberboss.png"
 		}

--- a/manifest/net.dextraspace/author.json
+++ b/manifest/net.dextraspace/author.json
@@ -1,0 +1,8 @@
+{
+	"author": {
+		"ExampleAuthor": {
+			"url": "https://github.com/Cyberboss",
+			"icon": "https://github.com/Cyberboss.png"
+		}
+	}
+}


### PR DESCRIPTION
- [x] The mod id starts with the same id as the author folder: `net.dextraspace.WorldOrbDynVars`
- [x] The harmony id matches the mod id if Harmony is used: `Harmony harmony = new("net.dextraspace.WorldOrbDynVars");`
- [x] All used links are valid
- [x] Your `ResoniteMod.Version` must match the version being added in the manifest and follow [Semantic Versioning](https://semver.org/): `1.0.2`
- [x] Your `AssemblyVersion` and `AssemblyFileVersion` match the mod version above: `1.0.2`
- [x] You have included an accurate `sha256` hash for each artifact: `dc38bd8b75ba5772f7da0d0970efe38b182ae1ba8495512cd062103129c24737`
- [x] Do not remove old mods. Instead, use the `deprecated` flag
- [x] Follow the [Resonite Policies and Guidelines](https://resonite.com/policies/) and [Mod Submission Guidelines](https://github.com/resonite-modding-group/resonite-mod-manifest/wiki/Submission-Guidelines)

