### PR TITLE
Deprecate redundant/broken mods

### DIFF
--- a/manifest/com.__Choco__/CustomShaderLib/info.json
+++ b/manifest/com.__Choco__/CustomShaderLib/info.json
@@ -4,6 +4,9 @@
 	"description": "Removes shader validation and verification, in order to allow custom shaders.",
 	"category": "Libraries",
 	"sourceLocation": "https://github.com/AwesomeTornado/Resonite-CustomShaderLib",
+	"flags": [
+		"deprecated"
+	],
 	"versions": {
 		"1.0.1": {
 			"releaseUrl": "https://github.com/AwesomeTornado/Resonite-CustomShaderLib/releases/tag/v1.0.1",

--- a/manifest/com.__Choco__/ResoniteMP3/info.json
+++ b/manifest/com.__Choco__/ResoniteMP3/info.json
@@ -4,6 +4,9 @@
 	"description": "Usually, resonite imports MP3 files as videos. This mod auto converts MP3 files into OGG files on import so that they import as audio files.",
 	"category": "Asset Importing",
 	"sourceLocation": "https://github.com/AwesomeTornado/ResoniteMP3",
+	"flags": [
+		"deprecated"
+	],
 	"versions": {
 		"3.0.0": {
 			"releaseUrl": "https://github.com/AwesomeTornado/ResoniteMP3/releases/tag/V3.0.0",


### PR DESCRIPTION
<!-- This template is provided for your convenience: feel free to delete it from your PR -->
- [x] The mod id starts with the same id as the author folder (ie: "com.example.ExampleModName")
- [x] The harmony id matches the mod id if Harmony is used. (ie "Harmony harmony = new("com.example.ExampleModName"))
- [x] All used links are valid
- [x] Your `ResoniteMod.Version` must match the version being added in the manifest and follow [Semantic Versioning](https://semver.org/)
- [x] Your `AssemblyVersion` and `AssemblyFileVersion` match the mod version above
- [x] You have included an accurate `sha256` hash for each artifact
- [x] Do not remove old mods. Instead, use the `deprecated` flag
- [x] Follow the [Resonite Policies and Guidelines](https://resonite.com/policies/) and [Mod Submission Guidelines](https://github.com/resonite-modding-group/resonite-mod-manifest/wiki/Submission-Guidelines)

I unfortunately don't have the time I used to, and I am not currently able to ensure that my mods are up to date and working.

 - ResoniteMP3 is known to be broken
 - CustomShaderLib is useless with DoublePrecision being marked as deprecated.

I'm not sure that it would be a good idea to remove all of my mods at once as many of them still work and are used by many people. I will, however, be marking my mods as deprecated if/when I am notified that they are no longer working.