### PR TITLE
Deprecate mods for recently upstreamed fixes

### DIFF
--- a/manifest/fr.baplar/JustLetItGo/info.json
+++ b/manifest/fr.baplar/JustLetItGo/info.json
@@ -1,10 +1,11 @@
 {
 	"name": "JustLetItGo",
 	"id": "fr.baplar.JustLetItGo",
-	"description": "Improves the behavior of the local asset queue, in particular to work around the 'clogging' that can sometimes affect it",
+	"description": "Improves the behavior of the local asset queue, in particular to work around the 'clogging' that can sometimes affect it. Experimental mod, may help but might also cause crashes, use at your own peril!",
 	"category": "Bug Workaround",
 	"sourceLocation": "https://forge.chapril.org/Baplar/Resonite.JustLetItGo",
 	"tags": [
+	  "experimental",
 		"stuck",
 		"clear",
 		"gather",

--- a/manifest/fr.baplar/JustLetItGo/info.json
+++ b/manifest/fr.baplar/JustLetItGo/info.json
@@ -5,7 +5,7 @@
 	"category": "Bug Workaround",
 	"sourceLocation": "https://forge.chapril.org/Baplar/Resonite.JustLetItGo",
 	"tags": [
-	  "experimental",
+		"experimental",
 		"stuck",
 		"clear",
 		"gather",

--- a/manifest/fr.baplar/LinuxSortedFiles/info.json
+++ b/manifest/fr.baplar/LinuxSortedFiles/info.json
@@ -2,6 +2,7 @@
 	"name": "LinuxSortedFiles",
 	"id": "fr.baplar.LinuxSortedFiles",
 	"description": "Improves the behavior of the Files dashboard tab on Linux, by sorting files by name.",
+	"flags": ["deprecated"],
 	"category": "Technical Tweaks",
 	"sourceLocation": "https://github.com/Baplar/ResoniteLinuxSortedFiles",
 	"platforms": ["linux"],

--- a/manifest/fr.baplar/ResoniteDiscordRpc/info.json
+++ b/manifest/fr.baplar/ResoniteDiscordRpc/info.json
@@ -2,6 +2,7 @@
 	"name": "ResoniteDiscordRpc",
 	"id": "fr.baplar.ResoniteDiscordRpc",
 	"description": "Adds fancy features to the Discord Rich Presence integration.",
+	"flags": ["deprecated"],
 	"category": "Misc",
 	"sourceLocation": "https://github.com/Baplar/ResoniteDiscordRpc",
 	"platforms": ["linux", "windows"],


### PR DESCRIPTION
<!-- This template is provided for your convenience: feel free to delete it from your PR -->
- [x] The mod id starts with the same id as the author folder (ie: "com.example.ExampleModName")
- [x] The harmony id matches the mod id if Harmony is used. (ie "Harmony harmony = new("com.example.ExampleModName"))
- [x] All used links are valid
- [x] Your `ResoniteMod.Version` must match the version being added in the manifest and follow [Semantic Versioning](https://semver.org/)
- [x] Your `AssemblyVersion` and `AssemblyFileVersion` match the mod version above
- [x] You have included an accurate `sha256` hash for each artifact
- [x] Do not remove old mods. Instead, use the `deprecated` flag
- [x] Follow the [Resonite Policies and Guidelines](https://resonite.com/policies/) and [Mod Submission Guidelines](https://github.com/resonite-modding-group/resonite-mod-manifest/wiki/Submission-Guidelines)

Two of my mods were implementing some Linux-specific fixes, but their root issue have been fixed upstream in Resonite, so these mods no longer need to exist.
Also, I added experimental warning and tag to JustLetItGo, for clearing my conscience.