### PR TITLE
Update MoreReferenceProxies 1.1.0

### DIFF
--- a/manifest/com.GrandtheUK/MoreReferenceProxies/info.json
+++ b/manifest/com.GrandtheUK/MoreReferenceProxies/info.json
@@ -19,7 +19,7 @@
 			"artifacts": [
 				{
 					"url": "https://github.com/GrandtheUK/MoreReferenceProxies/releases/download/v1.1.0/MoreReferenceProxies.dll",
-					"sha256": "2f34e5f1cab92143094a5dc038d94a324a4a9796d8c1132bb9bd190e925921eb"
+					"sha256": "af5a4a94138dbf15b1f9930c45177708f61066a3642b94bc98f7b76489e315ee"
 				}
 			]
 		}

--- a/manifest/com.GrandtheUK/MoreReferenceProxies/info.json
+++ b/manifest/com.GrandtheUK/MoreReferenceProxies/info.json
@@ -13,6 +13,15 @@
 					"sha256": "736a2016413f3b2f4c2db1d2d26468c7c0b8e2c34dffca61b5ee4f02f1adf54e"
 				}
 			]
+		},
+		"1.1.0": {
+			"releaseUrl": "https://github.com/GrandtheUK/MoreReferenceProxies/releases/tag/v1.1.0",
+			"artifacts": [
+				{
+					"url": "https://github.com/GrandtheUK/MoreReferenceProxies/releases/download/v1.1.0/MoreReferenceProxies.dll",
+					"sha256": "2f34e5f1cab92143094a5dc038d94a324a4a9796d8c1132bb9bd190e925921eb"
+				}
+			]
 		}
 	},
     "additionalAuthors": [


### PR DESCRIPTION
Updating MoreReferenceProxies to v1.1.0

- [x] The mod id starts with the same id as the author folder (ie: "com.example.ExampleModName")
- [x] The harmony id matches the mod id if Harmony is used. (ie "Harmony harmony = new("com.example.ExampleModName"))
- [x] All used links are valid
- [x] Your `ResoniteMod.Version` must match the version being added in the manifest and follow [Semantic Versioning](https://semver.org/)
- [x] Your `AssemblyVersion` and `AssemblyFileVersion` match the mod version above
- [x] You have included an accurate `sha256` hash for each artifact
- [x] Do not remove old mods. Instead, use the `deprecated` flag
- [x] Follow the [Resonite Policies and Guidelines](https://resonite.com/policies/) and [Mod Submission Guidelines](https://github.com/resonite-modding-group/resonite-mod-manifest/wiki/Submission-Guidelines)
