### PR TITLE
Update ReferenceFinderWizard's ContextMenuHookLib dependency version

### DIFF
--- a/manifest/owo.Nytra/ReferenceFinderWizard/info.json
+++ b/manifest/owo.Nytra/ReferenceFinderWizard/info.json
@@ -49,7 +49,7 @@
 		"1.2.1": {
 			"dependencies": {
 				"org.yosh.ContextMenuHookLib": {
-					"version": "^1.0.0",
+					"version": "^1.0.2",
 					"optional": true
 				}
 			},


### PR DESCRIPTION
This is the version it has been built against